### PR TITLE
plugin_proxy: fix race condition in input thread initialization.

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -135,9 +135,11 @@ static int flb_proxy_input_cb_exit(void *in_context, struct flb_config *config)
     if (ctx->proxy->def->proxy == FLB_PROXY_GOLANG) {
         proxy_go_input_destroy(ctx->proxy->data);
     }
-    flb_plugin_proxy_destroy(ctx->proxy);
 
     flb_input_thread_destroy(it, ctx->ins);
+
+    flb_plugin_proxy_destroy(ctx->proxy);
+
     flb_free(ctx);
 
     return 0;

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -315,7 +315,6 @@ int flb_plugin_proxy_input_init(struct flb_plugin_proxy *proxy,
         return -1;
     }
 
-    ctx->it.coll_fd = ret;
     /* Before to initialize for proxy, set the proxy instance reference */
     ctx->proxy = proxy;
 
@@ -358,6 +357,7 @@ int flb_plugin_proxy_input_init(struct flb_plugin_proxy *proxy,
         flb_error("Could not set collector for threaded proxy input plugin");
         goto init_error;
     }
+    ctx->it.coll_fd = ret;
 
     return ret;
 

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -313,26 +313,6 @@ int flb_plugin_proxy_input_init(struct flb_plugin_proxy *proxy,
         return -1;
     }
 
-    /* create worker thread */
-    ret = flb_input_thread_init(&ctx->it, proxy_cb_in_thread_callback, &ctx->it);
-    if (ret) {
-        flb_errno();
-        flb_error("Could not initialize worker thread");
-        goto init_error;
-    }
-
-    /* Set the context */
-    flb_input_set_context(i_ins, &ctx->it);
-
-    /* Collect upon data available on the pipe read fd */
-    ret = flb_input_set_collector_event(i_ins,
-                                        flb_input_thread_collect,
-                                        ctx->it.read,
-                                        config);
-    if (ret == -1) {
-        flb_error("Could not set collector for threaded proxy input plugin");
-        goto init_error;
-    }
     ctx->it.coll_fd = ret;
     /* Before to initialize for proxy, set the proxy instance reference */
     ctx->proxy = proxy;
@@ -354,6 +334,27 @@ int flb_plugin_proxy_input_init(struct flb_plugin_proxy *proxy,
     else {
         fprintf(stderr, "[proxy] unrecognized input proxy handler %i\n",
                 proxy->def->proxy);
+    }
+
+    /* create worker thread */
+    ret = flb_input_thread_init(&ctx->it, proxy_cb_in_thread_callback, &ctx->it);
+    if (ret) {
+        flb_errno();
+        flb_error("Could not initialize worker thread");
+        goto init_error;
+    }
+
+    /* Set the context */
+    flb_input_set_context(i_ins, &ctx->it);
+
+    /* Collect upon data available on the pipe read fd */
+    ret = flb_input_set_collector_event(i_ins,
+                                        flb_input_thread_collect,
+                                        ctx->it.read,
+                                        config);
+    if (ret == -1) {
+        flb_error("Could not set collector for threaded proxy input plugin");
+        goto init_error;
     }
 
     return ret;


### PR DESCRIPTION
The input worker thread will de-reference ctx->proxy before it can be initialized under certain circumstances if the thread is started too early. This change merely delays the initialization of the input thread until the ctx variable is fully initialized. The call to flb_input_set_collector_event must be made after initializing the thread or it will not run.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
