### PR TITLE
plugin_proxy: destroy input context data after exiting the input thread.

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -132,11 +132,11 @@ static int flb_proxy_input_cb_exit(void *in_context, struct flb_config *config)
     it = in_context;
     ctx = container_of(it, struct flb_plugin_input_proxy_thread_config, it);
 
+    flb_input_thread_destroy(it, ctx->ins);
+
     if (ctx->proxy->def->proxy == FLB_PROXY_GOLANG) {
         proxy_go_input_destroy(ctx->proxy->data);
     }
-
-    flb_input_thread_destroy(it, ctx->ins);
 
     flb_plugin_proxy_destroy(ctx->proxy);
 


### PR DESCRIPTION
Yet another fix for input thread exiting. Here I moved the freeing of the context data after exiting the input thread otherwise the input can sometimes run when the data is freed causing a use after free. This tends to trigger more often on darwin/arm64 and under gdb than in normal use.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
