### PR TITLE
[Canary] add workflow for windows unit testing

### DIFF
--- a/.github/workflows/call-windows-unit-tests.yaml
+++ b/.github/workflows/call-windows-unit-tests.yaml
@@ -1,0 +1,180 @@
+---
+name: Reusable workflow to run unit tests on Windows packages (only for x86 and x64)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: The version of Fluent Bit to create.
+        type: string
+        required: true
+      ref:
+        description: The commit, tag or branch of Fluent Bit to checkout for building that creates the version above.
+        type: string
+        required: true
+      environment:
+        description: The Github environment to run this workflow on.
+        type: string
+        required: false
+      unstable:
+        description: Optionally add metadata to build to indicate an unstable build, set to the contents you want to add.
+        type: string
+        required: false
+        default: ''
+    secrets:
+      token:
+        description: The Github token or similar to authenticate with.
+        required: true
+      bucket:
+        description: The name of the S3 (US-East) bucket to push packages into.
+        required: false
+      access_key_id:
+        description: The S3 access key id for the bucket.
+        required: false
+      secret_access_key:
+        description: The S3 secret access key for the bucket.
+        required: false
+
+jobs:
+  call-windows-unit-test-get-meta:
+    name: Determine build info
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      armSupported: ${{ steps.armcheck.outputs.armSupported }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Determine if we are doing a build with ARM support
+        id: armcheck
+        # Check for new contents from https://github.com/fluent/fluent-bit/pull/6621
+        run: |
+          if grep -q "winarm64" CMakeLists.txt ; then
+            echo "armSupported=true" >> $GITHUB_OUTPUT
+          else
+            echo "armSupported=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+  call-build-windows-unit-test:
+    runs-on: windows-latest
+    environment: ${{ inputs.environment }}
+    needs:
+      - call-windows-unit-test-get-meta
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "Windows 32bit"
+            arch: x86
+            openssl_dir: C:\vcpkg\packages\openssl_x86-windows-static
+            cmake_additional_opt: ""
+            vcpkg_triplet: x86-windows-static
+          - name: "Windows 64bit"
+            arch: x64
+            openssl_dir: C:\vcpkg\packages\openssl_x64-windows-static
+            cmake_additional_opt: ""
+            vcpkg_triplet: x64-windows-static
+    permissions:
+      contents: read
+    # Default environment variables can be overridden below. To prevent library pollution - without this other random libraries may be found on the path leading to failures.
+    env:
+      PATH: C:\ProgramData\Chocolatey\bin;c:/Program Files/Git/cmd;c:/Windows/system32;C:/Windows/System32/WindowsPowerShell/v1.0;$ENV:WIX/bin;C:/Program Files/CMake/bin;C:\vcpkg;
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Get dependencies
+        run: |
+          Invoke-WebRequest -OutFile winflexbison.zip $env:WINFLEXBISON
+          Expand-Archive winflexbison.zip -Destination C:\WinFlexBison
+          Copy-Item -Path C:\WinFlexBison/win_bison.exe C:\WinFlexBison/bison.exe
+          Copy-Item -Path C:\WinFlexBison/win_flex.exe C:\WinFlexBison/flex.exe
+          echo "C:\WinFlexBison" | Out-File -FilePath $env:GITHUB_PATH -Append
+        env:
+          WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
+        shell: pwsh
+
+      - name: Set up with Developer Command Prompt for Microsoft Visual C++
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.config.arch }}
+
+      - name: Get gzip command w/ chocolatey
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: install gzip -y
+
+      # http://man7.org/linux/man-pages/man1/date.1.html
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Restore cached packages of vcpkg
+        id: cache-unit-test-vcpkg-sources
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            C:\vcpkg\packages
+          key: ${{ runner.os }}-${{ matrix.config.arch }}-wintest-vcpkg-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.config.arch }}-wintest-vcpkg-
+          enableCrossOsArchive: false
+
+      - name: Build openssl with vcpkg
+        run: |
+          C:\vcpkg\vcpkg install --recurse openssl --triplet ${{ matrix.config.vcpkg_triplet }}
+        shell: cmd
+
+      - name: Build libyaml with vcpkg
+        run: |
+          C:\vcpkg\vcpkg install --recurse libyaml --triplet ${{ matrix.config.vcpkg_triplet }}
+        shell: cmd
+
+      - name: Save packages of vcpkg
+        id: save-vcpkg-sources
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            C:\vcpkg\packages
+          key: ${{ steps.cache-unit-test-vcpkg-sources.outputs.cache-primary-key }}
+          enableCrossOsArchive: false
+
+      - name: run unit-test for Fluent Bit packages (only for x86 and x64)
+        run: |
+          cmake -G "NMake Makefiles" `
+            -D FLB_TESTS_INTERNAL=On `
+            -D FLB_NIGHTLY_BUILD='${{ inputs.unstable }}' `
+            -D OPENSSL_ROOT_DIR='${{ matrix.config.openssl_dir }}' `
+            ${{ matrix.config.cmake_additional_opt }} `
+            -D FLB_LIBYAML_DIR=C:\vcpkg\packages\libyaml_${{ matrix.config.vcpkg_triplet }} `
+            -D FLB_WITHOUT_flb-rt-out_elasticsearch=On `
+            -D FLB_WITHOUT_flb-rt-out_td=On `
+            -D FLB_WITHOUT_flb-rt-out_forward=On `
+            -D FLB_WITHOUT_flb-rt-in_disk=On `
+            -D FLB_WITHOUT_flb-rt-in_proc=On `
+            -D FLB_WITHOUT_flb-it-parser=On `
+            -D FLB_WITHOUT_flb-it-unit_sizes=On `
+            -D FLB_WITHOUT_flb-it-network=On `
+            -D FLB_WITHOUT_flb-it-pack=On `
+            -D FLB_WITHOUT_flb-it-signv4=On `
+            -D FLB_WITHOUT_flb-it-aws_credentials=On `
+            -D FLB_WITHOUT_flb-it-aws_credentials_ec2=On `
+            -D FLB_WITHOUT_flb-it-aws_credentials_http=On `
+            -D FLB_WITHOUT_flb-it-aws_credentials_profile=On `
+            -D FLB_WITHOUT_flb-it-aws_credentials_sts=On `
+            -D FLB_WITHOUT_flb-it-aws_util=On `
+            -D FLB_WITHOUT_flb-it-input_chunk=On `
+            ../
+          cmake --build .
+          ctest --build-run-dir $PWD --output-on-failure
+        shell: pwsh
+        working-directory: build

--- a/.github/workflows/pr-windows-build.yaml
+++ b/.github/workflows/pr-windows-build.yaml
@@ -38,3 +38,14 @@ jobs:
       environment: pr
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+
+  run-windows-unit-tests:
+    needs:
+      - pr-windows-build
+    uses: ./.github/workflows/call-windows-unit-tests.yaml
+    with:
+      version: ${{ github.sha }}
+      ref: ${{ github.sha }}
+      environment: pr
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/internal/file.c
+++ b/tests/internal/file.c
@@ -8,6 +8,9 @@
 #define TEXT_FILE    FLB_TESTS_DATA_PATH "/data/file/text_file.txt"
 #define EMPTY_FILE    FLB_TESTS_DATA_PATH "/data/file/empty_file.txt"
 
+#define NEWLINE "\n"
+#define CRNEWLINE "\r\n"
+
 static void check_equals(flb_sds_t result, const char *expected)
 {
     size_t expected_len = strlen(expected);
@@ -23,7 +26,13 @@ static void check_equals(flb_sds_t result, const char *expected)
 static void test_file_read_text_file()
 {
     flb_sds_t result = flb_file_read(TEXT_FILE);
-    check_equals(result, "Some text file\n\nline 3\n\nline 5\n");
+    /* In Windows, \n is replaced with \r\n by git settings. */
+    if (strstr(result, "\r\n") != NULL) {
+      check_equals(result, "Some text file\r\n\r\nline 3\r\n\r\nline 5\r\n");
+    }
+    else {
+      check_equals(result, "Some text file\n\nline 3\n\nline 5\n");
+    }
     flb_sds_destroy(result);
 }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
